### PR TITLE
Fix new bot match seeding.

### DIFF
--- a/apiserver/apiserver/coordinator/matchmaking.py
+++ b/apiserver/apiserver/coordinator/matchmaking.py
@@ -388,7 +388,7 @@ def find_newbie_seed_player(conn, ranked_users, seed_filter):
     :return:
     """
     sqlfunc = sqlalchemy.sql.func
-    game_curve = 1 / (model.bots.c.games_played + 1)
+    game_curve = 1.0 / (model.bots.c.games_played + 1)
     # weight the curve between half and full weight
     rand_factor = 0.5 + (sqlfunc.random() * 0.5)
     # Since the curve is cut in half every doubling of games, this means a bot


### PR DESCRIPTION
Postgresql has true integer division, resulting in game_curve always being 0 if a player has any games at all and giving no differentiation between players.