### PR TITLE
compiler: stop forcing cpp std on cpp (not cmake!)

### DIFF
--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -356,8 +356,8 @@ comp_args = {
         ["vbnc", "-out:%s.exe" % BOT],
     ],
     "C++": [
-        ["g++", "-O3", "-w", "-std=c++11", "-c"],
-        ["g++", "-O2", "-lm", "-std=c++11", "-o", BOT],
+        ["g++", "-O3", "-w", "-c"],
+        ["g++", "-O2", "-lm", "-o", BOT],
     ],
     "D": [
         ["dmd", "-O", "-inline", "-release", "-noboundscheck", "-version=StdLoggerDisableLogging", "-of" + BOT],


### PR DESCRIPTION
Note that CMake path is unaffected. g++ 7 defaults to cpp14 and our provided kit is cpp14. This will also make it more future-proof. We also already don't force the version for the C compilation.