### PR TITLE
Set more reasonable challenge game highlighting.

### DIFF
--- a/website/_sass/_game-feed.scss
+++ b/website/_sass/_game-feed.scss
@@ -65,7 +65,7 @@
             font-size: 14px;
             background-color: #f9fcff;
             &.challenge{
-              background-color: #2e2e1f;
+              background-color: #e7f7ff;
             }
             .video-icon {
               display: inline-block;

--- a/website/_sass/_user-profile.scss
+++ b/website/_sass/_user-profile.scss
@@ -516,7 +516,7 @@
           background-color: #f9fcff;
         }
         tbody > tr > td.challenge {
-          background-color: #f9fcff;
+          background-color: #e7f7ff;
         }
         .winner {
           color: #20a257;


### PR DESCRIPTION
Currently in the game feed the background for challenge games is much too
dark, making it hard to read player names.

On other hand the player profile page sets the challenge game background
to the same color as other games.

This changes to a light cyan color for both pages.

Current game feed:
![image](https://user-images.githubusercontent.com/392930/47252149-b7e98d00-d40d-11e8-9fbb-66a7ba5c4948.png)

New game feed:
![image](https://user-images.githubusercontent.com/392930/47252195-67266400-d40e-11e8-93a4-5072c019b652.png)

New player profile feed:
![image](https://user-images.githubusercontent.com/392930/47252163-d2bc0180-d40d-11e8-8f23-942e62dac0f6.png)
