### PR TITLE
Fix missing validation on zip MIME types

### DIFF
--- a/website/javascript/templates/Play.vue
+++ b/website/javascript/templates/Play.vue
@@ -241,7 +241,8 @@
       },
       upload_bot(files) {
         window.scrollTo(0, 0)
-        if (files.length && files[0].type === "application/zip") {
+        const zipTypes = ["application/zip", "application/octet-stream", "application/x-zip-compressed", "multipart/x-zip"]
+        if (files.length && zipTypes.includes(files[0].type)) {
           this.botFile = files[0]
           this.currentView = 'botUpload'
         } else {

--- a/website/javascript/templates/Play.vue
+++ b/website/javascript/templates/Play.vue
@@ -241,8 +241,8 @@
       },
       upload_bot(files) {
         window.scrollTo(0, 0)
-        const zipTypes = ["application/zip", "application/octet-stream", "application/x-zip-compressed", "multipart/x-zip"]
-        if (files.length && zipTypes.includes(files[0].type)) {
+        this.zipTypes = ["application/zip", "application/octet-stream", "application/x-zip-compressed", "multipart/x-zip"]
+        if (files.length && this.zipTypes.includes(files[0].type)) {
           this.botFile = files[0]
           this.currentView = 'botUpload'
         } else {


### PR DESCRIPTION
Validation for zip uploads only allows MIME type === "application/zip" when some browsers report other MIME types