### PR TITLE
Remove special-casing for "RandomBot" in compiler

### DIFF
--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -45,7 +45,7 @@ def safeglob(pattern):
     for root, dirs, files in os.walk("."):
         files = fnmatch.filter(files, pattern)
         for fname in files:
-            if SAFEPATH.match(fname) and os.path.splitext(fname)[0] != "RandomBot":
+            if SAFEPATH.match(fname):
                 safepaths.append(os.path.join(root, fname))
     return safepaths
 


### PR DESCRIPTION
Had some extremely odd compilation errors in Scala. Once I renamed the `RandomBot.scala` file in my project to `MyRandomBot.scala`, my bot started compiling when submitted.

Was this intentional?