### PR TITLE
Bugfix for missing map update count in nightmare tool

### DIFF
--- a/tools/nightmare/nightmare.py
+++ b/tools/nightmare/nightmare.py
@@ -53,6 +53,7 @@ def nightmare(replay, player_id):
             for dropoff in dropoffs[player_index]:
                 yield '{} {} {}'.format(dropoff['id'], dropoff['location']['x'], dropoff['location']['y'])
 
+        yield str(len(frame['cells']))
         for cell in frame['cells']:
             yield '{} {} {}'.format(cell['x'], cell['y'], cell['production'])
 


### PR DESCRIPTION
I notice when trying to feed the output of nightmare to my client that nightmare failed to output the map cell update count per game frame, which was easy enough to fix.