### PR TITLE
golang starter kit: adds Player.GetShip(shipId) method and makes Entity.id and Ship.E.id accessible.

### DIFF
--- a/starter_kits/Go/src/hlt/Entities.go
+++ b/starter_kits/Go/src/hlt/Entities.go
@@ -13,6 +13,9 @@ type Entity struct {
 	Pos      *Position
 }
 
+// GetID - Gets an entity's ID, which is unique within their subtype.
+func (e *Entity) GetID() int { return e.id }
+
 /*********************************************************************************/
 
 // Dropoff - Dropoff structure

--- a/starter_kits/Go/src/hlt/Entities.go
+++ b/starter_kits/Go/src/hlt/Entities.go
@@ -54,6 +54,9 @@ func NewShip(playerID int) *Ship {
 	return &Ship{&Entity{shipID, playerID, &Position{x, y}}, halite}
 }
 
+// GetID - Get a Ship's ID
+func (s *Ship) GetID() int { return s.E.id }
+
 // IsFull - Returns true if the ship is full
 func (s *Ship) IsFull() bool {
 	var maxHalite, _ = gameconfig.GetInstance().GetInt(gameconfig.MaxHalite)

--- a/starter_kits/Go/src/hlt/Player.go
+++ b/starter_kits/Go/src/hlt/Player.go
@@ -30,10 +30,8 @@ func NewPlayer() *Player {
 
 // GetShip - Get a specific Ship by its ID.
 func (p *Player) GetShip(shipId int) (*Ship, error) {
-	for i := 0; i < len(p.Ships); i++ {
-		if p.Ships[i].GetID() == shipId {
-			return p.Ships[i], nil
-		}
+	if ship, ok := p.Ships[shipId]; ok {
+		return ship, nil
 	}
 	return nil, errors.New(fmt.Sprintf("No ship with ID %d", shipId))
 }

--- a/starter_kits/Go/src/hlt/Player.go
+++ b/starter_kits/Go/src/hlt/Player.go
@@ -1,6 +1,7 @@
 package hlt
 
 import (
+	"errors"
 	"fmt"
 	"hlt/input"
 )
@@ -25,6 +26,16 @@ func NewPlayer() *Player {
 	var x, _ = input.GetInt()
 	var y, _ = input.GetInt()
 	return &Player{playerID, NewShipyard(playerID, &Position{x, y}), 0, nil, nil}
+}
+
+// GetShip - Get a specific Ship by its ID.
+func (p *Player) GetShip(shipId int) (*Ship, error) {
+	for i := 0; i < len(p.Ships); i++ {
+		if p.Ships[i].GetID() == shipId {
+			return p.Ships[i], nil
+		}
+	}
+	return nil, errors.New(fmt.Sprintf("No ship with ID %d", shipId))
 }
 
 // Update - Updates the player, reading the ships and dropoffs data


### PR DESCRIPTION
It'd be helpful if we can make Entity.id a readable value to our own implementation. I'm porting my Python implementation to golang which relies on Ship.id being a readable value in a number of cases.

golang's Ship instance only provides a pointer to Position, which is significantly less convenient to work with. Example from my own implementation: near the middle/end of each turn, each ship AI returns a slice of their preferred moves on the next turn descending by preference. Each ship's actual move is decided by a swarm AI which helps avoid collisions and optimize overall positions. Without Entity.id accessible, we need to generate our own ID for each ship and perform a mix of internal accounting operations between swarm AI and ship AIs to track which ship ID is where based on the Position pointer where they were last expected to be.

Making Entity.id accessible also brings golang's starter kit closer to the API documented on the site which allows accessing specific ship instances via Player.get_ship(ship_id). Players can't access an entity by an ID which is inaccessible to them.

refs:
- https://halite.io/learn-programming-challenge/api-docs#player
- https://github.com/HaliteChallenge/Halite-III/blob/master/starter_kits/Python3/hlt/game_map.py#L20

Thanks for the great golang starter kit!