### PR TITLE
Fix engine turn limit option.

### DIFF
--- a/game_engine/main.cpp
+++ b/game_engine/main.cpp
@@ -76,6 +76,7 @@ int main(int argc, char *argv[]) {
 
     if (turn_limit_arg.isSet()) {
         constants.MAX_TURNS = turn_limit_arg.getValue();
+        constants.MIN_TURNS = turn_limit_arg.getValue();
     }
 
     if (strict_switch.isSet()) {


### PR DESCRIPTION
The option was only setting `constants.MAX_TURNS`, the actual result of this is dependent on the map size and limit set. But if the map size was larger than `constants.MIN_TURN_THRESHOLD` and the limit set was less than `constants.MIN_TURNS` this would result in some very large turn limit actually being used. Thanks, unsigned integer math.

Problem initially reported [on the forums by nkelly13](https://forums.halite.io/t/no-effect-from-turn-limit-option-to-halite-cli/551).