### PR TITLE
Update final "move" description.

### DIFF
--- a/website/learn-programming-challenge/game-overview.md
+++ b/website/learn-programming-challenge/game-overview.md
@@ -38,7 +38,7 @@ Command|Halite Cost or Gain
 Spawn | Cost: 1000 halite
 Convert into a drop-off  | Cost: 4000 halite deducted from player's stored halite. <br/> The converted ship's halite cargo and the halite in the sea under the new dropoff is credited to the player, potentially reducing the cost.
 Move (n, s, e w) | Cost: 10% of halite available at turn origin cell is deducted from ship’s current halite. <br/>When a ship moves over a friendly shipyard or dropoff, it deposits its halite cargo.
-Move (o) | Collect: 25% of halite available in cell, rounded up to the nearest whole number. <br/>Ships can carry up to 1000 halite.
+Collect (o) | Gain: 25% of halite available in cell, rounded up to the nearest whole number. <br/>Ships can carry up to 1000 halite.
 
 <br/><br/>
 


### PR DESCRIPTION
Fairly certain this should read "collect" rather than "move". In addition, changed the "Collect" to "Gain" in order to parallel the column title.