### PR TITLE
Fix an off by one error on tier icon indexing.

### DIFF
--- a/website/javascript/templates/TierPopover.vue
+++ b/website/javascript/templates/TierPopover.vue
@@ -27,7 +27,7 @@
     mounted: function () {
       const badgeIndex = badges.indexOf(this.tier)
       if (badgeIndex >= 0) {
-        this.index = badgeIndex
+        this.index = badgeIndex + 1
         this.badge = this.tier
         this.percentage = percentages[badgeIndex]
       }
@@ -49,7 +49,7 @@
     },
     computed: {
       icon() {
-        return `icon-tier-${this.index+1}`
+        return `icon-tier-${this.index}`
       }
     },
   }


### PR DESCRIPTION
The TierPopover was using a 1 based index, while recent changes assumed a 0 based index. This just brings everything back inline with 1 based indexing.