### PR TITLE
[Go starter kit] Enable developers to instantiate hlt.Position and make its coordinates available.

### DIFF
--- a/starter_kits/Go/src/hlt/Position.go
+++ b/starter_kits/Go/src/hlt/Position.go
@@ -8,6 +8,10 @@ type Position struct {
 	y int
 }
 
+func NewPosition(x int, y int) *Position {
+	return &Position{x, y}
+}
+
 func (p *Position) Coordinates() (int, int) {
 	return p.x, p.y
 }

--- a/starter_kits/Go/src/hlt/Position.go
+++ b/starter_kits/Go/src/hlt/Position.go
@@ -8,6 +8,10 @@ type Position struct {
 	y int
 }
 
+func (p *Position) Coordinates() (int, int) {
+	return p.x, p.y
+}
+
 func (p *Position) String() string {
 	return fmt.Sprintf("Pos{x=%d,y=%d}", p.x, p.y)
 }


### PR DESCRIPTION
Let's make Position coordinates available so they don't need to be extracted from the String() representation.