### PR TITLE
PHP Starter Bot: Fixed bug where dropoffs where being stored into the ships array

### DIFF
--- a/starter_kits/PHP/hlt/Player.php
+++ b/starter_kits/PHP/hlt/Player.php
@@ -48,7 +48,7 @@ class Player
         for ($i = 0; $i < $numDropoffs; ++$i) {
             $dropoff = Dropoff::_generate($this->id);
 
-            $this->ships[$dropoff->id->id] = $dropoff;
+            $this->dropoffs[$dropoff->id->id] = $dropoff;
         }
     }
 


### PR DESCRIPTION
Currently dropoffs are being stored as ships causing the typechecking of some of the later PHP functions to fail. This corrects the typo.