### PR TITLE
julia starter bot

### DIFF
--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -375,7 +375,7 @@ comp_args = {
         ["jar", "cfe", BOT + ".jar", BOT],
     ],
     "Julia": [
-        ["""JULIA_DEPOT_PATH=$(pwd) julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate()'"""],
+        ["JULIA_DEPOT_PATH=$(pwd) julia -e 'using Pkg; Pkg.instantiate()'"],
     ],
     "Haskell": [
         ["ghc", "--make", BOT + ".hs", "-O", "-v0", "-rtsopts"],


### PR DESCRIPTION
@lidavidm thanks but it didn't work. (ERROR: syntax: invalid identifier name ".") I'm guessing this is a bash error maybe. Either way I removed the activate(".") step since instantiate() should pick up the manifest in the current directory. 