### PR TITLE
Include gpu enabled flag with leaderboard.

### DIFF
--- a/apiserver/apiserver/web/leaderboard.py
+++ b/apiserver/apiserver/web/leaderboard.py
@@ -175,6 +175,7 @@ def leaderboard():
                 "num_games": int(row["num_games"]),
                 "score": float(row["score"]),
                 "language": row["language"],
+                "is_gpu_enabled": row["is_gpu_enabled"],
                 "country": row["country_code"],
                 "rank": int(row["rank"]) if row["rank"] is not None else None,
                 "organization_rank": int(row["organization_rank"]) if row["organization_rank"] is not None and row["organization_id"] is not None else None,


### PR DESCRIPTION
Return the `is_gpu_enabled` flag with the other user information in the leaderboard api results. This saves having to query every user individually.