### PR TITLE
Properly rank players that don't have halite to proceed

### DIFF
--- a/game_engine/core/HaliteImpl.cpp
+++ b/game_engine/core/HaliteImpl.cpp
@@ -520,9 +520,8 @@ void HaliteImpl::update_player_stats() {
                 player_stats.halite_per_dropoff[dropoff.location] = dropoff.deposited_halite;
             }
         } else {
-            // Keep updating their stats in any case
-            player_stats.turn_productions.push_back(player.energy);
-            player_stats.turn_deposited.push_back(player.total_energy_deposited);
+            player_stats.turn_productions.push_back(0);
+            player_stats.turn_deposited.push_back(0);
         }
     }
 }
@@ -593,6 +592,7 @@ void HaliteImpl::kill_player(const Player::id_type &player_id) {
         cell.entity = Entity::None;
         game.store.delete_entity(entity_id);
     }
+    player.energy = 0;
 }
 
 /**

--- a/game_engine/core/HaliteImpl.cpp
+++ b/game_engine/core/HaliteImpl.cpp
@@ -520,8 +520,9 @@ void HaliteImpl::update_player_stats() {
                 player_stats.halite_per_dropoff[dropoff.location] = dropoff.deposited_halite;
             }
         } else {
-            player_stats.turn_productions.push_back(0);
-            player_stats.turn_deposited.push_back(0);
+            // Keep updating their stats in any case
+            player_stats.turn_productions.push_back(player.energy);
+            player_stats.turn_deposited.push_back(player.total_energy_deposited);
         }
     }
 }
@@ -592,7 +593,6 @@ void HaliteImpl::kill_player(const Player::id_type &player_id) {
         cell.entity = Entity::None;
         game.store.delete_entity(entity_id);
     }
-    player.energy = 0;
 }
 
 /**

--- a/game_engine/core/HaliteImpl.cpp
+++ b/game_engine/core/HaliteImpl.cpp
@@ -467,11 +467,15 @@ bool HaliteImpl::game_ended() const {
                            });
     }
     long num_alive_players = 0;
-    for (auto &&[_, player] : game.store.players) {
+    for (auto &&[player_id, player] : game.store.players) {
         bool can_play = player_can_play(player);
         if (player.can_play && !can_play) {
             Logging::log("player has insufficient resources to continue", Logging::Level::Info, player.id);
             player.can_play = false;
+            // Update 'last turn alive' one last time (liveness lasts
+            // to the end of a turn)
+            auto& stats = game.game_statistics.player_statistics[player_id.value];
+            stats.last_turn_alive = game.turn_number;
         }
         if (!player.terminated && can_play) {
             num_alive_players++;


### PR DESCRIPTION
- "Last turn alive" was off by 1 turn
- Don't set player energy to 0 after they are ejected (terminated players aren't asked for moves anyways)
- Keep tracking some stats after a player is ejected so they can be ranked properly

Fixes #148.