### PR TITLE
Making Entity and Position hashable in Python3 starter kit

### DIFF
--- a/starter_kits/Python3/hlt/entity.py
+++ b/starter_kits/Python3/hlt/entity.py
@@ -29,6 +29,9 @@ class Entity(abc.ABC):
                                       self.id,
                                       self.position)
 
+    def __hash__(self):
+        return self.id
+
 
 class Dropoff(Entity):
     """

--- a/starter_kits/Python3/hlt/entity.py
+++ b/starter_kits/Python3/hlt/entity.py
@@ -30,7 +30,10 @@ class Entity(abc.ABC):
                                       self.position)
 
     def __hash__(self):
-        return self.id
+        return hash((self.owner, self.id))
+
+    def __eq__(self, other):
+        return self.owner == other.owner and self.id == other.id
 
 
 class Dropoff(Entity):

--- a/starter_kits/Python3/hlt/positionals.py
+++ b/starter_kits/Python3/hlt/positionals.py
@@ -109,3 +109,6 @@ class Position:
         return "{}({}, {})".format(self.__class__.__name__,
                                    self.x,
                                    self.y)
+
+    def __hash__(self):
+        return hash((self.x, self.y))


### PR DESCRIPTION
A nice way to speed things up is to pre-compute things and save them in a dict. For example:

```python
distance_by_position = {p: game_map.calculate_distance(ship.position, p) for p in positions}
```
You can then use it very easily in the built in functions min, max, sorted, etc.:

```python
sorted_positions = sorted(positions, key=distance_by_position.get)
best_position = min(positions, key=distance_by_position.get)
```

As of now, both Position and Entities are not hashable, meaning you can't use them as keys in a dict, or even save them in a set.

This PR implements the __hash__ method for both Position and Entity, making the above possible.