### PR TITLE
Auto normalizing positions for python starter kit

### DIFF
--- a/starter_kits/Python3/hlt/constants.py
+++ b/starter_kits/Python3/hlt/constants.py
@@ -58,3 +58,9 @@ def load_constants(constants):
 
     """An inspired ship instead spends 1/X% halite to move."""
     INSPIRED_MOVE_COST_RATIO = constants['INSPIRED_MOVE_COST_RATIO']
+
+
+def set_dimensions(width, height):
+    global WIDTH, HEIGHT
+    WIDTH = width
+    HEIGHT = height

--- a/starter_kits/Python3/hlt/constants.py
+++ b/starter_kits/Python3/hlt/constants.py
@@ -60,6 +60,7 @@ def load_constants(constants):
     INSPIRED_MOVE_COST_RATIO = constants['INSPIRED_MOVE_COST_RATIO']
 
 
+# TODO remove once width/height are sent by server (#78)
 def set_dimensions(width, height):
     global WIDTH, HEIGHT
     WIDTH = width

--- a/starter_kits/Python3/hlt/networking.py
+++ b/starter_kits/Python3/hlt/networking.py
@@ -36,6 +36,8 @@ class Game:
         self.me = self.players[self.my_id]
         self.game_map = GameMap._generate()
 
+        constants.set_dimensions(self.game_map.width, self.game_map.height)
+
     def ready(self, name):
         """
         Indicate that your bot is ready to play.

--- a/starter_kits/Python3/hlt/networking.py
+++ b/starter_kits/Python3/hlt/networking.py
@@ -36,6 +36,7 @@ class Game:
         self.me = self.players[self.my_id]
         self.game_map = GameMap._generate()
 
+        # TODO remove once width/height are sent by server (#78)
         constants.set_dimensions(self.game_map.width, self.game_map.height)
 
     def ready(self, name):

--- a/starter_kits/Python3/hlt/positionals.py
+++ b/starter_kits/Python3/hlt/positionals.py
@@ -1,4 +1,5 @@
 from . import commands
+from . import constants
 
 
 class Direction:
@@ -62,9 +63,16 @@ class Direction:
 
 
 class Position:
-    def __init__(self, x, y):
+    def __init__(self, x, y, normalize=True):
         self.x = x
         self.y = y
+
+        if normalize:
+            self.normalize()
+
+    def normalize(self):
+        self.x = self.x % constants.WIDTH
+        self.y = self.y % constants.HEIGHT
 
     def directional_offset(self, direction):
         """

--- a/starter_kits/Python3/hlt/positionals.py
+++ b/starter_kits/Python3/hlt/positionals.py
@@ -63,12 +63,11 @@ class Direction:
 
 
 class Position:
-    def __init__(self, x, y, normalize=True):
+    def __init__(self, x, y):
         self.x = x
         self.y = y
 
-        if normalize:
-            self.normalize()
+        self.normalize()
 
     def normalize(self):
         self.x = self.x % constants.WIDTH
@@ -97,11 +96,13 @@ class Position:
     def __iadd__(self, other):
         self.x += other.x
         self.y += other.y
+        self.normalize()
         return self
 
     def __isub__(self, other):
         self.x -= other.x
         self.y -= other.y
+        self.normalize()
         return self
 
     def __abs__(self):


### PR DESCRIPTION
This closes #78.

# Changes

This PR adds WIDTH and HEIGHT to constants, and adds a new `normalize` method to Position. This allows positions to be normalized without having to use the game map.

Further, Position is then modified to auto normalize itself in the constructor.

# Motivation
I believe this is necessary because of the consequences of not auto normalizing Positions. As I'm sure many of you are aware, Path Planning algorithms depend heavily on not expanding positions they've already evaluated. But, as a consequence of not auto normalizing positions, naive use of the Position class will result in much more work than expected. This is because Position equality and hashing does not take into account the width and height of the game. This leads to this effect in a 32x32 board:

```
>>> Position(0, 0) == Position(32, 32)
False
>>> game_map.normalize(Position(0, 0)) == game_map.normalize(Position(32, 32))
True
```

Consider this simple breadth first search code:

```python
def bfs(start: Position, goal: Position):
    explored = set()
    open = {start}
    while len(open) > 0:
        yield open

        next = set()
        for position in open:
            for neighbor in position.get_surrounding_cardinals():
                if neighbor not in explored:
                    next.add(neighbor)
                    explored.add(neighbor)
        open = next
```

This may actually cause an infinite loop with the current behavior. Think about what would happen if `start` was at `(0, 0)`. The neighbors generated in the first iteration would look like:

 `{(1, 0), (0, 1), (-1, 0), (0, -1)}`

Note that since we aren't normalize, there are Positions with negative xs and ys in that set. Now think ahead a bit to when the code reaches `(32, 32)`, which will happen because positions are not normalized. Now we know that `(0, 0)` is exactly the same square as `(32, 32)`, but the hashing function does not realize this. It sees that `(32, 32)` is not in the set of explored positions, so it adds it to the set so it can explore it. Now we will explore the exact same squares we've already explored, but with their xs and ys above 32. This causes an infinite loop.

Here is the correct code (as of now):

```python
def bfs(game_map, start: Position, goal: Position):
    explored = set()
    open = {game_map.normalize(start)}
    while len(open) > 0:
        yield open

        next = set()
        for position in open:
            for neighbor in position.get_surrounding_cardinals():
                neighbor = game_map.normalize(neighbor)
                if neighbor not in explored:
                    next.add(neighbor)
                    explored.add(neighbor)
        open = next
```

Of course, this code isn't that much different, and one could argue that it isn't hard to call `normalize()`, but I would argue that this subtlety of having to normalize positions isn't stressed enough, or at all in the docs. How is someone going to know that they have to do that? They won't.

This happened to me the other day... I was confused why my bot was timing out sometimes during my A* algorithm, because A* is pretty fast. I come to find out that its evaluating positions that have coordinates like `(-92, 48)` and things like that.

# Conclusion

Anyone who isn't using exclusively normalized positions is probably doing a lot of extra work or timing out more often than they should be, because any equality check or hash check on un-normalized positions will not work as expected.

**Note that this is a problem with every starting kit that doesn't auto normalize positions, but this PR only fixes the python start kit.**