### PR TITLE
Increment turn number when ending the game early

### DIFF
--- a/game_engine/core/HaliteImpl.cpp
+++ b/game_engine/core/HaliteImpl.cpp
@@ -161,6 +161,7 @@ void HaliteImpl::run_game() {
         game.replay.full_frames.back().add_end_state(game.store);
 
         if (game_ended()) {
+            game.turn_number++;
             break;
         }
     }


### PR DESCRIPTION
Fixes #178 

This makes the final stats and player ranks get calculated correctly.

I believe this is the correct thing to do here, but not completely confident that it won't cause other issues. In particular that there isn't something else that is depending on the turn number not incrementing when the game ended early.

This does fix the issue with a player that is terminated on the last turn but having more halite than the last player alive ranking above them.