### PR TITLE
Minor tweaks to finals setup

### DIFF
--- a/apiserver/apiserver/coordinator/matchmaking.py
+++ b/apiserver/apiserver/coordinator/matchmaking.py
@@ -494,7 +494,7 @@ def find_seed_player(conn, ranked_users, seed_filter):
             model.bots.c.compile_status == model.CompileStatus.SUCCESSFUL.value
         ).order_by(model.bots.c.games_played.asc()
         ).limit(20).alias("least_played").select().order_by(
-            sqlalchemy.sql.func.rand()
+            sqlalchemy.sql.func.random()
         ).limit(1)
 
         return conn.execute(least_played).first()

--- a/apiserver/apiserver/scripts/rating_reset.py
+++ b/apiserver/apiserver/scripts/rating_reset.py
@@ -34,7 +34,7 @@ def main(args=sys.argv[1:]):
                         model.ranked_bots.c.user_id,
                         model.ranked_bots.c.bot_id,
                         model.ranked_bots.c.version_number,
-                        sqlalchemy.sql.text("ranked_bots.bot_rank"),
+                        model.ranked_bots.c.bot_rank,
                         model.ranked_bots.c.score,
                         sqlalchemy.sql.text("tr.*"),
                         model.ranked_bots.c.games_played,


### PR DESCRIPTION
- Fixes the matchmaking seed player query for PostgreSQL (use RANDOM instead of RAND)
- Update the ranking reset to use the reflected `bot_rank` column (instead of splicing text into the query)

Fixes #196.