### PR TITLE
Compile Julia bots during compilation phase

### DIFF
--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -375,7 +375,7 @@ comp_args = {
         ["jar", "cfe", BOT + ".jar", BOT],
     ],
     "Julia": [
-        ["JULIA_DEPOT_PATH=\$(pwd) julia -e 'using Pkg; Pkg.activate(\\\".\\\"); Pkg.instantiate()'"],
+        ["JULIA_DEPOT_PATH=\$(pwd) julia -e 'using Pkg; Pkg.activate(\\\".\\\"); Pkg.instantiate(); Pkg.API.precompile(); using Halite3'"],
     ],
     "Kotlin": [
         ["kotlinc", "-include-runtime", "-d", BOT + ".jar"],

--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -375,7 +375,7 @@ comp_args = {
         ["jar", "cfe", BOT + ".jar", BOT],
     ],
     "Julia": [
-        ["JULIA_DEPOT_PATH=\$(pwd) julia -e 'using Pkg; Pkg.activate(\\\".\\\"); Pkg.instantiate(); Pkg.API.precompile(); using Halite3'"],
+        ["JULIA_DEPOT_PATH=\$(pwd) julia -e 'using Pkg; Pkg.activate(\\\".\\\"); Pkg.instantiate(); Pkg.API.precompile(); try using Halite3 catch end'"],
     ],
     "Kotlin": [
         ["kotlinc", "-include-runtime", "-d", BOT + ".jar"],


### PR DESCRIPTION
Julia uses lazy compilation and compiles code when it is first used. Before this PR bots written in Julia are compiled when the code if first used, i.e during the initialization phase. This unfairly limits the amount of code and packages that can be used in Julia projects.

This PR triggers compilation of Julia projects during the compilation phase of Halite3.