### PR TITLE
Always precompile Julia bots on every game

### DIFF
--- a/apiserver/worker/worker.py
+++ b/apiserver/worker/worker.py
@@ -248,6 +248,22 @@ def setupParticipant(user_index, user, temp_dir):
     # group
     give_ownership(bot_dir, bot_group, 0o2770)
 
+    # For Julia bots, they -must- be precompiled before each game, as
+    # Julia's cache file stores absolute paths to source directories.
+    with open(os.path.join(bot_dir, "run.sh")) as lang_file:
+        lang = lang_file.readline().strip().lower()
+        if lang == "#julia":
+            for command in compiler.comp_args["Julia"]:
+                cmd = COMPILE_COMMAND.format(
+                    cgroup=bot_cgroup,
+                    bot_dir=bot_dir,
+                    bot_group=bot_group,
+                    bot_user=bot_user,
+                    command="JULIA_DEPOT_PATH=\$(pwd) julia --project -e 'try using Halite3 catch end'",
+                )
+                print("Precompiling Julia:", cmd)
+                subprocess.run(cmd, cwd=bot_dir, shell=True)
+
     bot_command = BOT_COMMAND.format(
         cgroup=bot_cgroup,
         bot_dir=bot_dir,


### PR DESCRIPTION
@Andersgee 

This is the only way I can get Julia to not recompile everything on bot startup - by recompiling it before we start the game. My hunch (after running `strings` on a precompiled file) is that the cache file contains absolute paths, so moving the file around breaks the precompilation. Testing this, I precompiled @Andersgee's bot in the REPL, then renamed the parent directory and tried to import the module; it again recompiled the bot.

This is not a particularly extensible solution, and is hardcoded to how @Andersgee's bot works. It should at least not hurt bots that don't use his structure (we don't check the status code of the precompile command). I'm rather hesitant to offer this up right before finals, but otherwise, Julia players are at a disadvantage.